### PR TITLE
Allow override defaults and regexp whitelist

### DIFF
--- a/squid/files/squid.conf
+++ b/squid/files/squid.conf
@@ -9,11 +9,9 @@
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing
 # should be allowed
-acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
-acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
-acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
-acl localnet src fc00::/7       # RFC 4193 local private network range
-acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+{%- for src in cfg_squid.get('allowed_src', ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7', 'fe80::/10']) %}
+acl localnet src {{ src }}
+{%- endfor %}
 
 {%- if cfg_squid.get('deprecated_localhost_acl', False) %}
 acl localhost src 127.0.0.1
@@ -23,16 +21,11 @@ acl localhost src ::1
 acl manager url_regex -i ^cache_object:// /squid-internal-mgr/
 
 acl SSL_ports port 443
-acl Safe_ports port 80		# http
-acl Safe_ports port 21		# ftp
-acl Safe_ports port 443		# https
-acl Safe_ports port 70		# gopher
-acl Safe_ports port 210		# wais
-acl Safe_ports port 1025-65535	# unregistered ports
-acl Safe_ports port 280		# http-mgmt
-acl Safe_ports port 488		# gss-http
-acl Safe_ports port 591		# filemaker
-acl Safe_ports port 777		# multiling http
+
+{%- for port in cfg_squid.get('safe_ports', ['80', '21', '443', '70', '210', '1025-65535', '280', '488', '591', '777']) %}
+acl Safe_ports port {{ port }}
+{%- endfor %}
+
 acl CONNECT method CONNECT
 
 # Set cache manager user and password

--- a/squid/files/squid.conf
+++ b/squid/files/squid.conf
@@ -94,6 +94,12 @@ acl {{acl}} dstdomain {{domain}}
 {%- endfor %}
 {% endfor %}
 
+{%- for acl, domains in cfg_squid.get('url_regex_acl', {}).items() %}
+{%- for domain in domains %}
+acl {{acl}} url_regex {{domain}}
+{%- endfor %}
+{% endfor %}
+
 {%- for rule in cfg_squid.get('http_access', []) %}
 http_access {{rule}}
 {%- endfor %}


### PR DESCRIPTION
- allow overriding src networks (backwards compatible)
- allow overriding safe_ports (backwards compatible)
- allow specifying 'url_regex' acl entries