### PR TITLE
Optimized configuration mapping

### DIFF
--- a/squid/files/squid.conf
+++ b/squid/files/squid.conf
@@ -9,7 +9,7 @@
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing
 # should be allowed
-{%- for src in cfg_squid.get('allowed_src', ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7', 'fe80::/10']) %}
+{%- for src in cfg_squid.get('allowed_src', map.allowed_src) %}
 acl localnet src {{ src }}
 {%- endfor %}
 
@@ -22,7 +22,7 @@ acl manager url_regex -i ^cache_object:// /squid-internal-mgr/
 
 acl SSL_ports port 443
 
-{%- for port in cfg_squid.get('safe_ports', ['80', '21', '443', '70', '210', '1025-65535', '280', '488', '591', '777']) %}
+{%- for port in cfg_squid.get('safe_ports', map.safe_ports) %}
 acl Safe_ports port {{ port }}
 {%- endfor %}
 
@@ -108,7 +108,7 @@ http_access {{rule}}
 http_access deny all
 
 # Squid normally listens to port 3128
-{%- for http_port in cfg_squid.get('http_port', ['3128']) %}
+{%- for http_port in cfg_squid.get('http_port', map.http_port) %}
 http_port {{http_port}}
 {%- endfor %}
 

--- a/squid/map.jinja
+++ b/squid/map.jinja
@@ -1,3 +1,5 @@
+{# All default values are defined in the 'Ubuntu' section. It is set as base, therefor only
+different values has to be set for other operating systems. This lowers configuration redundancy. #}
 {% set map = salt['grains.filter_by']({
     'Ubuntu': {
         'pkgs': ['squid'],
@@ -10,14 +12,9 @@
         'pkgs': ['squid3'],
         'service': 'squid3',
         'conf_dir': '/etc/squid3',
-        'conf_file': 'squid.conf',
-        'cache': '/var/spool/squid',
     },
     'FreeBSD': {
-        'pkgs': ['squid'],
-        'service': 'squid',
         'conf_dir': '/usr/local/etc/squid',
-        'conf_file': 'squid.conf',
         'cache': '/var/squid/cache',
      },
-}, grain='os', merge=salt['pillar.get']('squid:lookup')) %}
+}, grain='os', merge=salt['pillar.get']('squid:lookup'), base='Ubuntu') %}

--- a/squid/map.jinja
+++ b/squid/map.jinja
@@ -7,6 +7,9 @@ different values has to be set for other operating systems. This lowers configur
         'conf_dir': '/etc/squid',
         'conf_file': 'squid.conf',
         'cache': '/var/spool/squid',
+        'allowed_src': ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7', 'fe80::/10'],
+        'safe_ports': ['80', '21', '443', '70', '210', '1025-65535', '280', '488', '591', '777'],
+        'http_port': ['3128'],
     },
     'Debian': {
         'pkgs': ['squid3'],


### PR DESCRIPTION
Over all it is a cleanup pull request to centralize configuration parameter end lessen their redundant usage in map.jinja.

For backward compatibility to new feature of joe-bowman of overwriting e.g. allowed_src I did not exclusivly use values from map.jinja. So now it is possible to overwrite them directly or via lookup.

```
squid:
  lookup:
    allowed_src:
      - '10.0.0.0/8'
```
is the same as
```
squid:
  allowed_src:
    - '10.0.0.0/8'
```
